### PR TITLE
Stop showing stopped nodes as running

### DIFF
--- a/packages/app/src/routes/node/[name]/+page.svelte
+++ b/packages/app/src/routes/node/[name]/+page.svelte
@@ -98,12 +98,6 @@ async function updateConfig() {
 }
 
 $effect(() => {
-  if (dockerStatus.isRunning) {
-    packagesStore.loadInstalledPackages();
-  }
-});
-
-$effect(() => {
   if (isInstalled && packageName) {
     loadConfig();
   }
@@ -111,6 +105,7 @@ $effect(() => {
 
 onMount(async () => {
   dockerStatus.startPolling();
+  await packagesStore.loadInstalledPackages({ force: true });
   if (isInstalled) {
     await loadConfig();
   }

--- a/packages/app/src/routes/package/+page.svelte
+++ b/packages/app/src/routes/package/+page.svelte
@@ -120,12 +120,6 @@ async function updateConfig() {
 }
 
 $effect(() => {
-  if (dockerStatus.isRunning) {
-    packagesStore.loadInstalledPackages();
-  }
-});
-
-$effect(() => {
   if (isInstalled) {
     loadConfig();
   }
@@ -133,6 +127,7 @@ $effect(() => {
 
 onMount(async () => {
   dockerStatus.startPolling();
+  await packagesStore.loadInstalledPackages({ force: true });
 });
 
 onDestroy(() => {


### PR DESCRIPTION
## Summary
- treat packages as installed only when all containers report 
- load installed package metadata once when opening node/package screens to avoid hammering the backend
- remove the docker-status effect that kept re-fetching and left the UI stuck on "Checking node status..."

## Testing
- just lint-js
- just lint-rs
