### PR TITLE
Navigate to manage nodes after installs

### DIFF
--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -299,7 +299,12 @@ onDestroy(() => {
               <Button
                 size="sm"
                 variant="default"
-                onclick={() => installPackage(name)}
+                onclick={async () => {
+                  const installed = await installPackage(name);
+                  if (installed) {
+                    managePackage(name);
+                  }
+                }}
                 disabled={disabled}
                 class="w-full"
               >

--- a/packages/app/src/routes/packages/+page.svelte
+++ b/packages/app/src/routes/packages/+page.svelte
@@ -150,7 +150,12 @@ onMount(() => {
               <Button
                 size="sm"
                 variant="default"
-                onclick={() => installPackage(name)}
+                onclick={async () => {
+                  const installed = await installPackage(name);
+                  if (installed) {
+                    managePackage(name);
+                  }
+                }}
                 disabled={dockerStatus.isRunning !== true || isInstallingPackage}
                 class="w-full"
               >


### PR DESCRIPTION
## Summary
- navigate to the manage node view after installing from the dashboard running nodes section
- do the same for installs triggered from the package store, reusing the existing managePackage helper
- leave the package detail page flow unchanged so users stay with the management controls already on screen

## Testing
- just lint-js