### PR TITLE
Centralize package lookup helper usage

### DIFF
--- a/packages/core/src/application/delete_package.rs
+++ b/packages/core/src/application/delete_package.rs
@@ -1,12 +1,9 @@
-use crate::infra::package::{self, get_packages};
+use crate::infra::package;
 use eyre::Result;
 use tracing::info;
 
 pub async fn delete_package(name: &str, include_images: bool) -> Result<()> {
-    let package = get_packages()?
-        .get(name)
-        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))?
-        .clone();
+    let package = package::get_package_by_name(name)?;
 
     package::delete_package(&package, include_images).await?;
     info!("Package '{}' deleted successfully.", name);

--- a/packages/core/src/application/get_package_runtime_state.rs
+++ b/packages/core/src/application/get_package_runtime_state.rs
@@ -1,14 +1,8 @@
-use crate::{
-    domain::package::PackageRuntimeState,
-    infra::package::{self, get_packages},
-};
+use crate::{domain::package::PackageRuntimeState, infra::package};
 use eyre::Result;
 
 pub async fn get_package_runtime_state(name: &str) -> Result<PackageRuntimeState> {
-    let package = get_packages()?
-        .get(name)
-        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))?
-        .clone();
+    let package = package::get_package_by_name(name)?;
 
     package::get_package_runtime_state(&package).await
 }

--- a/packages/core/src/application/install_package.rs
+++ b/packages/core/src/application/install_package.rs
@@ -1,17 +1,11 @@
-use crate::infra::{
-    file::generate_jwt_secret,
-    package::{self, get_packages},
-    package_config::PackageConfigStore,
-};
+use crate::infra::{file::generate_jwt_secret, package, package_config::PackageConfigStore};
 use eyre::{Context, Result};
 use tracing::info;
 
 pub async fn install_package(name: &str) -> Result<()> {
     generate_jwt_secret().wrap_err("Failed to generate JWT secret")?;
 
-    let package = get_packages()?
-        .remove(name)
-        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))?;
+    let package = package::get_package_by_name(name)?;
 
     let config = PackageConfigStore::load(name)?;
     let network = config.values.get("network");

--- a/packages/core/src/application/resume_package.rs
+++ b/packages/core/src/application/resume_package.rs
@@ -1,12 +1,9 @@
-use crate::infra::package::{self, get_packages};
+use crate::infra::package;
 use eyre::Result;
 use tracing::info;
 
 pub async fn resume_package(name: &str) -> Result<()> {
-    let package = get_packages()?
-        .get(name)
-        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))?
-        .clone();
+    let package = package::get_package_by_name(name)?;
 
     package::resume_package(&package).await?;
     info!("Package '{}' resumed", name);

--- a/packages/core/src/application/stop_package.rs
+++ b/packages/core/src/application/stop_package.rs
@@ -1,12 +1,9 @@
-use crate::infra::package::{self, get_packages};
+use crate::infra::package;
 use eyre::Result;
 use tracing::info;
 
 pub async fn stop_package(name: &str) -> Result<()> {
-    let package = get_packages()?
-        .get(name)
-        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))?
-        .clone();
+    let package = package::get_package_by_name(name)?;
 
     package::stop_package(&package).await?;
     info!("Package '{}' stopped", name);

--- a/packages/core/src/infra/package.rs
+++ b/packages/core/src/infra/package.rs
@@ -18,6 +18,14 @@ pub fn get_packages() -> Result<HashMap<String, Package>> {
     Ok(packages)
 }
 
+/// Retrieves a single package or returns a not-found error.
+pub fn get_package_by_name(name: &str) -> Result<Package> {
+    let mut catalog = get_packages()?;
+    catalog
+        .remove(name)
+        .ok_or_else(|| eyre::eyre!("Package '{}' not found", name))
+}
+
 /// Gets a list of installed packages by checking their container states
 pub async fn get_installed_packages(packages: &HashMap<String, Package>) -> Result<Vec<Package>> {
     let docker = get_docker_instance().await?;


### PR DESCRIPTION
## Summary
- add a reusable helper to fetch packages by name and surface consistent errors
- replace repeated map access in package lifecycle functions with the new helper

## Testing
- just lint-rs
