### PR TITLE
Refactor validator filesystem checks

### DIFF
--- a/packages/core/src/application/validator/create_deposit_data.rs
+++ b/packages/core/src/application/validator/create_deposit_data.rs
@@ -1,3 +1,4 @@
+use super::filesystem::ensure_parent_secure;
 use super::ports::{CryptoProvider, ValidatorFilesystem};
 use crate::domain::validator::DepositData;
 use crate::infra::validator::{SimpleCryptoProvider, StdValidatorFilesystem};
@@ -134,13 +135,11 @@ where
             )
         })?;
 
-    if let Some(parent) = params.output_path.parent() {
-        filesystem
-            .ensure_secure_directory(parent)
-            .with_context(|| {
-                format!("invalid validator artifact directory: {}", parent.display())
-            })?;
-    }
+    ensure_parent_secure(
+        &params.output_path,
+        filesystem,
+        "invalid validator artifact directory",
+    )?;
 
     let mut deposit = crypto
         .create_deposit_data(

--- a/packages/core/src/application/validator/filesystem.rs
+++ b/packages/core/src/application/validator/filesystem.rs
@@ -1,0 +1,16 @@
+use super::ports::ValidatorFilesystem;
+use eyre::{Context, Result};
+use std::path::Path;
+
+pub(super) fn ensure_parent_secure<F: ValidatorFilesystem>(
+    path: &Path,
+    filesystem: &F,
+    context_label: &str,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        filesystem
+            .ensure_secure_directory(parent)
+            .with_context(|| format!("{context_label}: {}", parent.display()))?;
+    }
+    Ok(())
+}

--- a/packages/core/src/application/validator/mod.rs
+++ b/packages/core/src/application/validator/mod.rs
@@ -1,4 +1,5 @@
 mod create_deposit_data;
+mod filesystem;
 mod generate_keys;
 pub mod ports;
 


### PR DESCRIPTION
## Summary
- share a helper that ensures validator artifacts are written to secure directories
- use the helper across key generation and deposit data flows for consistent messaging

## Testing
- just test
- just lint-rs