### PR TITLE
Add deterministic web route integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "eyre",
  "kittynode-core",
  "serde",
+ "serde_json",
  "tokio",
  "tower",
  "tracing-subscriber",

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 tower = "0.5.2"
+serde_json = "1.0.128"

--- a/packages/web/src/test_harness.rs
+++ b/packages/web/src/test_harness.rs
@@ -1,0 +1,353 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{
+    Mutex, MutexGuard, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+use eyre::{Result, eyre};
+use kittynode_core::api as core_api;
+use kittynode_core::api::DockerStartStatus;
+use kittynode_core::api::types::{
+    Config, OperationalState, Package, PackageConfig, PackageRuntimeState, SystemInfo,
+};
+
+pub struct Harness {
+    pub add_capability: ResponseQueue<()>,
+    pub remove_capability: ResponseQueue<()>,
+    pub get_capabilities: ResponseQueue<Vec<String>>,
+    pub get_packages: ResponseQueue<HashMap<String, Package>>,
+    pub get_config: ResponseQueue<Config>,
+    pub install_package: ResponseQueue<()>,
+    pub delete_package: ResponseQueue<()>,
+    pub stop_package: ResponseQueue<()>,
+    pub resume_package: ResponseQueue<()>,
+    pub get_package_runtime_state: ResponseQueue<PackageRuntimeState>,
+    pub get_packages_runtime_state: ResponseQueue<HashMap<String, PackageRuntimeState>>,
+    pub get_installed_packages: ResponseQueue<Vec<Package>>,
+    pub is_docker_running: ResponseQueue<bool>,
+    pub init_kittynode: ResponseQueue<()>,
+    pub delete_kittynode: ResponseQueue<()>,
+    pub get_system_info: ResponseQueue<SystemInfo>,
+    pub get_container_logs: ResponseQueue<Vec<String>>,
+    pub get_package_config: ResponseQueue<PackageConfig>,
+    pub update_package_config: ResponseQueue<()>,
+    pub start_docker_if_needed: ResponseQueue<DockerStartStatus>,
+    pub get_operational_state: ResponseQueue<OperationalState>,
+    pub validate_web_port: ResponseQueue<u16>,
+    pub delete_package_calls: Vec<(String, bool)>,
+    pub update_package_config_calls: Vec<(String, PackageConfig)>,
+    pub validate_web_port_calls: Vec<u16>,
+    pub skip_server_start: bool,
+}
+
+impl Default for Harness {
+    fn default() -> Self {
+        Self {
+            add_capability: ResponseQueue::new("add_capability"),
+            remove_capability: ResponseQueue::new("remove_capability"),
+            get_capabilities: ResponseQueue::new("get_capabilities"),
+            get_packages: ResponseQueue::new("get_packages"),
+            get_config: ResponseQueue::new("get_config"),
+            install_package: ResponseQueue::new("install_package"),
+            delete_package: ResponseQueue::new("delete_package"),
+            stop_package: ResponseQueue::new("stop_package"),
+            resume_package: ResponseQueue::new("resume_package"),
+            get_package_runtime_state: ResponseQueue::new("get_package_runtime_state"),
+            get_packages_runtime_state: ResponseQueue::new("get_packages_runtime_state"),
+            get_installed_packages: ResponseQueue::new("get_installed_packages"),
+            is_docker_running: ResponseQueue::new("is_docker_running"),
+            init_kittynode: ResponseQueue::new("init_kittynode"),
+            delete_kittynode: ResponseQueue::new("delete_kittynode"),
+            get_system_info: ResponseQueue::new("get_system_info"),
+            get_container_logs: ResponseQueue::new("get_container_logs"),
+            get_package_config: ResponseQueue::new("get_package_config"),
+            update_package_config: ResponseQueue::new("update_package_config"),
+            start_docker_if_needed: ResponseQueue::new("start_docker_if_needed"),
+            get_operational_state: ResponseQueue::new("get_operational_state"),
+            validate_web_port: ResponseQueue::new("validate_web_port"),
+            delete_package_calls: Vec::new(),
+            update_package_config_calls: Vec::new(),
+            validate_web_port_calls: Vec::new(),
+            skip_server_start: false,
+        }
+    }
+}
+
+pub struct ResponseQueue<T> {
+    label: &'static str,
+    responses: VecDeque<Result<T>>,
+}
+
+impl<T> ResponseQueue<T> {
+    pub fn new(label: &'static str) -> Self {
+        Self {
+            label,
+            responses: VecDeque::new(),
+        }
+    }
+
+    pub fn push_ok(&mut self, value: T) {
+        self.responses.push_back(Ok(value));
+    }
+
+    pub fn push_err(&mut self, message: impl Into<String>) {
+        let message = message.into();
+        self.responses.push_back(Err(eyre!("{}", message)));
+    }
+
+    pub fn push_result(&mut self, result: Result<T>) {
+        self.responses.push_back(result);
+    }
+
+    pub fn next(&mut self) -> Result<T> {
+        self.responses
+            .pop_front()
+            .unwrap_or_else(|| Err(eyre!("No response registered for {}", self.label)))
+    }
+}
+
+static HARNESS: OnceLock<Mutex<Harness>> = OnceLock::new();
+static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static HARNESS_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+fn harness() -> &'static Mutex<Harness> {
+    HARNESS.get_or_init(|| Mutex::new(Harness::default()))
+}
+
+fn test_lock() -> &'static Mutex<()> {
+    TEST_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn lock_state() -> MutexGuard<'static, Harness> {
+    harness()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+fn lock_test() -> MutexGuard<'static, ()> {
+    test_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+fn is_active() -> bool {
+    HARNESS_ACTIVE.load(Ordering::SeqCst)
+}
+
+pub fn reset() {
+    let mut state = lock_state();
+    *state = Harness::default();
+    HARNESS_ACTIVE.store(false, Ordering::SeqCst);
+}
+
+pub struct HarnessGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl Drop for HarnessGuard {
+    fn drop(&mut self) {
+        reset();
+    }
+}
+
+pub fn with_harness<F>(configure: F) -> HarnessGuard
+where
+    F: FnOnce(&mut Harness),
+{
+    let lock = lock_test();
+
+    reset();
+    HARNESS_ACTIVE.store(true, Ordering::SeqCst);
+    let mut state = lock_state();
+    configure(&mut state);
+
+    HarnessGuard { _lock: lock }
+}
+
+pub fn read_state<F, R>(reader: F) -> R
+where
+    F: FnOnce(&Harness) -> R,
+{
+    let state = lock_state();
+    reader(&state)
+}
+
+pub fn should_skip_server_start() -> bool {
+    if !is_active() {
+        return false;
+    }
+    lock_state().skip_server_start
+}
+
+pub mod api {
+    use super::*;
+
+    pub fn add_capability(name: &str) -> Result<()> {
+        if !is_active() {
+            return core_api::add_capability(name);
+        }
+        lock_state().add_capability.next()
+    }
+
+    pub fn remove_capability(name: &str) -> Result<()> {
+        if !is_active() {
+            return core_api::remove_capability(name);
+        }
+        lock_state().remove_capability.next()
+    }
+
+    pub fn get_capabilities() -> Result<Vec<String>> {
+        if !is_active() {
+            return core_api::get_capabilities();
+        }
+        lock_state().get_capabilities.next()
+    }
+
+    pub fn get_packages() -> Result<HashMap<String, Package>> {
+        if !is_active() {
+            return core_api::get_packages();
+        }
+        lock_state().get_packages.next()
+    }
+
+    pub fn get_config() -> Result<Config> {
+        if !is_active() {
+            return core_api::get_config();
+        }
+        lock_state().get_config.next()
+    }
+
+    pub async fn install_package(name: &str) -> Result<()> {
+        if !is_active() {
+            return core_api::install_package(name).await;
+        }
+        lock_state().install_package.next()
+    }
+
+    pub async fn delete_package(name: &str, include_images: bool) -> Result<()> {
+        if !is_active() {
+            return core_api::delete_package(name, include_images).await;
+        }
+        let mut state = lock_state();
+        state
+            .delete_package_calls
+            .push((name.to_string(), include_images));
+        state.delete_package.next()
+    }
+
+    pub async fn stop_package(name: &str) -> Result<()> {
+        if !is_active() {
+            return core_api::stop_package(name).await;
+        }
+        lock_state().stop_package.next()
+    }
+
+    pub async fn resume_package(name: &str) -> Result<()> {
+        if !is_active() {
+            return core_api::resume_package(name).await;
+        }
+        lock_state().resume_package.next()
+    }
+
+    pub async fn get_package_runtime_state(name: &str) -> Result<PackageRuntimeState> {
+        if !is_active() {
+            return core_api::get_package_runtime_state(name).await;
+        }
+        lock_state().get_package_runtime_state.next()
+    }
+
+    pub async fn get_packages_runtime_state(
+        names: &[String],
+    ) -> Result<HashMap<String, PackageRuntimeState>> {
+        if !is_active() {
+            return core_api::get_packages_runtime_state(names).await;
+        }
+        lock_state().get_packages_runtime_state.next()
+    }
+
+    pub async fn get_installed_packages() -> Result<Vec<Package>> {
+        if !is_active() {
+            return core_api::get_installed_packages().await;
+        }
+        lock_state().get_installed_packages.next()
+    }
+
+    pub async fn is_docker_running() -> bool {
+        if !is_active() {
+            return core_api::is_docker_running().await;
+        }
+        lock_state()
+            .is_docker_running
+            .next()
+            .expect("test harness missing is_docker_running response")
+    }
+
+    pub fn init_kittynode() -> Result<()> {
+        if !is_active() {
+            return core_api::init_kittynode();
+        }
+        lock_state().init_kittynode.next()
+    }
+
+    pub fn delete_kittynode() -> Result<()> {
+        if !is_active() {
+            return core_api::delete_kittynode();
+        }
+        lock_state().delete_kittynode.next()
+    }
+
+    pub fn get_system_info() -> Result<SystemInfo> {
+        if !is_active() {
+            return core_api::get_system_info();
+        }
+        lock_state().get_system_info.next()
+    }
+
+    pub async fn get_container_logs(name: &str, tail: Option<usize>) -> Result<Vec<String>> {
+        if !is_active() {
+            return core_api::get_container_logs(name, tail).await;
+        }
+        lock_state().get_container_logs.next()
+    }
+
+    pub async fn get_package_config(name: &str) -> Result<PackageConfig> {
+        if !is_active() {
+            return core_api::get_package_config(name).await;
+        }
+        lock_state().get_package_config.next()
+    }
+
+    pub async fn update_package_config(name: &str, config: PackageConfig) -> Result<()> {
+        if !is_active() {
+            return core_api::update_package_config(name, config).await;
+        }
+        let mut state = lock_state();
+        state
+            .update_package_config_calls
+            .push((name.to_string(), config.clone()));
+        state.update_package_config.next()
+    }
+
+    pub async fn start_docker_if_needed() -> Result<DockerStartStatus> {
+        if !is_active() {
+            return core_api::start_docker_if_needed().await;
+        }
+        lock_state().start_docker_if_needed.next()
+    }
+
+    pub async fn get_operational_state() -> Result<OperationalState> {
+        if !is_active() {
+            return core_api::get_operational_state().await;
+        }
+        lock_state().get_operational_state.next()
+    }
+}
+
+pub fn validate_web_port(port: u16) -> Result<u16> {
+    if !is_active() {
+        return core_api::validate_web_port(port);
+    }
+    let mut state = lock_state();
+    state.validate_web_port_calls.push(port);
+    state.validate_web_port.next()
+}

--- a/packages/web/tests/routes.rs
+++ b/packages/web/tests/routes.rs
@@ -1,22 +1,320 @@
+use std::collections::HashMap;
+
 use axum::{
-    body::Body,
-    http::{Request, StatusCode},
+    Router,
+    body::{Body, to_bytes},
+    http::{Method, Request, StatusCode},
+    response::Response,
 };
+use kittynode_core::api::DockerStartStatus;
+use kittynode_core::api::types::{
+    OperationalMode, OperationalState, PackageConfig, PackageRuntimeState,
+};
+use kittynode_web::{app, read_state, run_with_port, with_harness};
+use serde::de::DeserializeOwned;
+use serde_json::json;
 use tower::ServiceExt;
 
-#[tokio::test]
-async fn get_package_config_route_is_registered() {
-    let app = kittynode_web::app();
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/get_package_config/test")
-                .body(Body::empty())
-                .expect("failed to build request"),
-        )
+async fn call(router: &Router, request: Request<Body>) -> Response {
+    router
+        .clone()
+        .oneshot(request)
         .await
-        .expect("service call failed");
+        .expect("service call failed")
+}
 
-    assert_ne!(response.status(), StatusCode::NOT_FOUND);
+async fn response_body_string(response: Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    String::from_utf8(bytes.to_vec()).expect("response body was not utf-8")
+}
+
+async fn response_json<T: DeserializeOwned>(response: Response) -> T {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read json body");
+    serde_json::from_slice(&bytes).expect("failed to deserialize json body")
+}
+
+fn get(path: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .body(Body::empty())
+        .expect("failed to build GET request")
+}
+
+fn post(path: &str, body: Body) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(body)
+        .expect("failed to build POST request")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn add_capability_route_reports_statuses() {
+    let _guard = with_harness(|h| {
+        h.add_capability.push_ok(());
+        h.add_capability.push_err("capability operation failed");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, post("/add_capability/demo", Body::empty())).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+
+    let err_response = call(&router, post("/add_capability/demo", Body::empty())).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "capability operation failed"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_capabilities_route_serializes_core_response() {
+    let capabilities = vec!["alpha".to_string(), "beta".to_string()];
+
+    let _guard = with_harness(|h| {
+        h.get_capabilities.push_ok(capabilities.clone());
+        h.get_capabilities.push_err("capabilities unavailable");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, get("/get_capabilities")).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+    let body: Vec<String> = response_json(ok_response).await;
+    assert_eq!(body, capabilities);
+
+    let err_response = call(&router, get("/get_capabilities")).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "capabilities unavailable"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn update_package_config_forwards_payload_and_errors() {
+    let values = HashMap::from([
+        ("network".to_string(), "hoodi".to_string()),
+        ("pruning".to_string(), "archive".to_string()),
+    ]);
+
+    let _guard = with_harness(|h| {
+        h.update_package_config.push_ok(());
+        h.update_package_config.push_err("write failed");
+    });
+
+    let router = app();
+    let body = Body::from(
+        json!({
+            "values": {
+                "network": "hoodi",
+                "pruning": "archive"
+            }
+        })
+        .to_string(),
+    );
+
+    let ok_response = call(&router, post("/update_package_config/demo", body)).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+
+    let recorded = read_state(|state| state.update_package_config_calls.clone());
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].0, "demo");
+    assert_eq!(recorded[0].1.values, values);
+
+    let err_body = Body::from(json!({ "values": {} }).to_string());
+    let err_response = call(&router, post("/update_package_config/demo", err_body)).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response_body_string(err_response).await, "write failed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn delete_package_includes_query_flag() {
+    let _guard = with_harness(|h| {
+        h.delete_package.push_ok(());
+        h.delete_package.push_err("delete blocked");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, post("/delete_package/demo", Body::empty())).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+
+    let err_response = call(
+        &router,
+        post("/delete_package/demo?include_images=true", Body::empty()),
+    )
+    .await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response_body_string(err_response).await, "delete blocked");
+
+    let calls = read_state(|state| state.delete_package_calls.clone());
+    assert_eq!(
+        calls,
+        vec![("demo".to_string(), false), ("demo".to_string(), true),]
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn docker_status_route_uses_boolean_outcome() {
+    let _guard = with_harness(|h| {
+        h.is_docker_running.push_ok(true);
+        h.is_docker_running.push_ok(false);
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, get("/is_docker_running")).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+
+    let err_response = call(&router, get("/is_docker_running")).await;
+    assert_eq!(err_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "Docker is not running"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn operational_state_route_maps_results() {
+    let state = OperationalState {
+        mode: OperationalMode::Remote,
+        docker_running: true,
+        can_install: false,
+        can_manage: true,
+        diagnostics: vec!["looks good".to_string()],
+    };
+
+    let _guard = with_harness(|h| {
+        h.get_operational_state.push_ok(state.clone());
+        h.get_operational_state.push_err("cannot read state");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, get("/get_operational_state")).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+    let body: OperationalState = response_json(ok_response).await;
+    assert_eq!(body.diagnostics, state.diagnostics);
+    assert_eq!(body.mode, state.mode);
+
+    let err_response = call(&router, get("/get_operational_state")).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "cannot read state"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn package_runtime_route_returns_payload() {
+    let runtime = PackageRuntimeState { running: true };
+
+    let _guard = with_harness(|h| {
+        h.get_package_runtime_state.push_ok(runtime.clone());
+        h.get_package_runtime_state.push_err("runtime unavailable");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, get("/package_runtime/demo")).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+    let body: PackageRuntimeState = response_json(ok_response).await;
+    assert_eq!(body.running, true);
+
+    let err_response = call(&router, get("/package_runtime/demo")).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "runtime unavailable"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn package_config_route_returns_json_and_errors() {
+    let config = PackageConfig {
+        values: HashMap::from([
+            ("api".to_string(), "enabled".to_string()),
+            ("slots".to_string(), "1024".to_string()),
+        ]),
+    };
+
+    let _guard = with_harness(|h| {
+        h.get_package_config.push_ok(config.clone());
+        h.get_package_config.push_err("config unavailable");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, get("/get_package_config/demo")).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+    let body: PackageConfig = response_json(ok_response).await;
+    assert_eq!(body.values, config.values);
+
+    let err_response = call(&router, get("/get_package_config/demo")).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "config unavailable"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn start_docker_route_relays_core_status() {
+    let _guard = with_harness(|h| {
+        h.start_docker_if_needed
+            .push_ok(DockerStartStatus::Starting);
+        h.start_docker_if_needed.push_err("auto-start disabled");
+    });
+
+    let router = app();
+
+    let ok_response = call(&router, post("/start_docker_if_needed", Body::empty())).await;
+    assert_eq!(ok_response.status(), StatusCode::OK);
+    let body: DockerStartStatus = response_json(ok_response).await;
+    assert_eq!(body, DockerStartStatus::Starting);
+
+    let err_response = call(&router, post("/start_docker_if_needed", Body::empty())).await;
+    assert_eq!(err_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response_body_string(err_response).await,
+        "auto-start disabled"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_with_port_respects_validate_web_port_failures() {
+    let _guard = with_harness(|h| {
+        h.validate_web_port.push_err("port rejected");
+    });
+
+    let error = run_with_port(4242)
+        .await
+        .expect_err("run_with_port should fail");
+    assert_eq!(error.to_string(), "port rejected");
+
+    let calls = read_state(|state| state.validate_web_port_calls.clone());
+    assert_eq!(calls, vec![4242]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_with_port_skips_server_when_configured() {
+    let _guard = with_harness(|h| {
+        h.validate_web_port.push_ok(5151);
+        h.skip_server_start = true;
+    });
+
+    run_with_port(5151)
+        .await
+        .expect("run_with_port should succeed when server start skipped");
+
+    let calls = read_state(|state| state.validate_web_port_calls.clone());
+    assert_eq!(calls, vec![5151]);
 }


### PR DESCRIPTION
## Summary
- add a test harness that injects deterministic responses for the web router while falling back to kittynode-core when idle
- exercise the primary web routes via tower::ServiceExt::oneshot covering success and failure cases
- capture validate_web_port behaviour through the harness and allow run_with_port to short-circuit in tests

## Testing
- cargo test -p kittynode-web