### PR TITLE
Add config persistence tests for configuration toggles

### DIFF
--- a/packages/core/src/application/set_auto_start_docker.rs
+++ b/packages/core/src/application/set_auto_start_docker.rs
@@ -15,10 +15,7 @@ pub fn set_auto_start_docker(enabled: bool) -> Result<()> {
 mod tests {
     use super::set_auto_start_docker;
     use crate::domain::config::Config;
-    use crate::infra::{
-        config::ConfigStore,
-        file::with_kittynode_path_override,
-    };
+    use crate::infra::{config::ConfigStore, file::with_kittynode_path_override};
     use tempfile::tempdir;
 
     #[test]

--- a/packages/core/src/application/set_onboarding_completed.rs
+++ b/packages/core/src/application/set_onboarding_completed.rs
@@ -14,10 +14,7 @@ pub fn set_onboarding_completed(completed: bool) -> Result<()> {
 mod tests {
     use super::set_onboarding_completed;
     use crate::domain::config::Config;
-    use crate::infra::{
-        config::ConfigStore,
-        file::with_kittynode_path_override,
-    };
+    use crate::infra::{config::ConfigStore, file::with_kittynode_path_override};
     use tempfile::tempdir;
 
     #[test]

--- a/packages/core/src/application/set_server_url.rs
+++ b/packages/core/src/application/set_server_url.rs
@@ -61,10 +61,7 @@ pub fn set_server_url(endpoint: String) -> Result<()> {
 mod tests {
     use super::{apply_server_url, set_server_url, validate_server_url};
     use crate::domain::config::Config;
-    use crate::infra::{
-        config::ConfigStore,
-        file::with_kittynode_path_override,
-    };
+    use crate::infra::{config::ConfigStore, file::with_kittynode_path_override};
     use tempfile::tempdir;
 
     #[test]

--- a/packages/core/src/infra/file.rs
+++ b/packages/core/src/infra/file.rs
@@ -149,7 +149,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         let panic_result = panic::catch_unwind(AssertUnwindSafe(|| {
-            with_kittynode_path_override(temp_dir.path(), || -> () {
+            with_kittynode_path_override(temp_dir.path(), || {
                 panic!("intentional test panic");
             })
         }));


### PR DESCRIPTION
## Summary
- add a test-only override harness for config path resolution to avoid env mutations
- cover set_auto_start_docker, set_onboarding_completed, and set_server_url end-to-end
- extend file helper tests to ensure overrides and panic unwinding are safe

## Testing
- cargo test -p kittynode-core
