### PR TITLE
Align Docker terminology

### DIFF
--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -397,7 +397,7 @@ onDestroy(() => {
         <Card.Content>
           <p class="text-sm text-muted-foreground">
             Docker needs to be running to view and manage packages. Please start
-            Docker Desktop and return to this page.
+            Docker and return to this page.
           </p>
         </Card.Content>
       </Card.Root>

--- a/packages/app/src/routes/node/[name]/+page.svelte
+++ b/packages/app/src/routes/node/[name]/+page.svelte
@@ -363,7 +363,7 @@ onDestroy(() => {
         <Terminal class="size-4" />
         <Alert.Title>Docker is not running</Alert.Title>
         <Alert.Description>
-          Start Docker Desktop to manage this node.
+          Start Docker to manage this node.
         </Alert.Description>
       </Alert.Root>
     {:else if installedStatus === "error"}
@@ -386,7 +386,7 @@ onDestroy(() => {
         <Terminal class="size-4" />
         <Alert.Title>Docker is not available</Alert.Title>
         <Alert.Description>
-          Start Docker Desktop to manage this node.
+          Start Docker to manage this node.
         </Alert.Description>
       </Alert.Root>
     {:else if packageStatus === "unknown"}

--- a/packages/app/src/routes/settings/+page.svelte
+++ b/packages/app/src/routes/settings/+page.svelte
@@ -377,7 +377,7 @@ async function checkForUpdates() {
         Docker
       </Card.Title>
       <Card.Description>
-        Control how Kittynode interacts with Docker Desktop
+        Control how Kittynode interacts with Docker
       </Card.Description>
     </Card.Header>
     <Card.Content>
@@ -387,7 +387,7 @@ async function checkForUpdates() {
             Auto-start Docker
           </p>
           <p class="text-xs text-muted-foreground">
-            Start Docker Desktop when Kittynode launches
+            Start Docker when Kittynode launches
           </p>
         </div>
         {#if configLoading && !configInitialized}

--- a/packages/core/src/application/start_docker.rs
+++ b/packages/core/src/application/start_docker.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use std::path::Path;
 
 pub async fn start_docker() -> Result<()> {
-    info!("Attempting to start Docker Desktop");
+    info!("Attempting to start Docker");
 
     #[cfg(target_os = "macos")]
     {
@@ -15,10 +15,10 @@ pub async fn start_docker() -> Result<()> {
             .arg("Docker")
             .spawn()
             .map_err(|e| {
-                error!("Failed to start Docker Desktop on macOS: {}", e);
-                eyre!("Failed to start Docker Desktop: {}. Please ensure Docker Desktop is installed.", e)
+                error!("Failed to start Docker on macOS: {}", e);
+                eyre!("Failed to start Docker: {e}. Please ensure Docker is installed.")
             })?;
-        info!("Docker Desktop start command sent on macOS");
+        info!("Docker start command sent on macOS");
     }
 
     #[cfg(target_os = "linux")]
@@ -41,16 +41,16 @@ pub async fn start_docker() -> Result<()> {
 
         for (cmd, args) in attempts {
             if Command::new(cmd).args(&args).spawn().is_ok() {
-                info!("Started Docker Desktop using: {} {:?}", cmd, args);
+                info!("Started Docker using: {} {:?}", cmd, args);
                 started = true;
                 break;
             }
         }
 
         if !started {
-            error!("Failed to start Docker Desktop on Linux after trying all methods");
+            error!("Failed to start Docker on Linux after trying all methods");
             return Err(eyre!(
-                "Failed to start Docker Desktop. Please ensure Docker Desktop is installed and try starting it manually."
+                "Failed to start Docker. Please ensure Docker is installed and try starting it manually."
             ));
         }
     }
@@ -84,7 +84,7 @@ pub async fn start_docker() -> Result<()> {
                     .is_ok()
                 {
                     started = true;
-                    info!("Started Docker Desktop from: {}", expanded_path);
+                    info!("Started Docker from: {}", expanded_path);
                     break;
                 }
             }
@@ -101,16 +101,16 @@ pub async fn start_docker() -> Result<()> {
                         .is_ok()
                     {
                         started = true;
-                        info!("Started Docker Desktop using PATH");
+                        info!("Started Docker using PATH");
                     }
                 }
             }
         }
 
         if !started {
-            error!("Failed to start Docker Desktop on Windows");
+            error!("Failed to start Docker on Windows");
             return Err(eyre!(
-                "Failed to start Docker Desktop. Please ensure Docker Desktop is installed and try starting it manually."
+                "Failed to start Docker. Please ensure Docker is installed and try starting it manually."
             ));
         }
     }

--- a/packages/core/src/application/start_docker_if_needed.rs
+++ b/packages/core/src/application/start_docker_if_needed.rs
@@ -116,7 +116,7 @@ pub async fn start_docker_if_needed() -> Result<DockerStartStatus> {
         evaluation
     };
 
-    info!("Starting Docker Desktop via auto-start preference");
+    info!("Starting Docker via auto-start preference");
     match start_docker().await {
         Ok(()) => Ok(evaluation.status),
         Err(err) => {


### PR DESCRIPTION
## Summary
- update settings card copy to refer to Docker consistently
- refresh alerts and home messaging to drop Docker Desktop wording
- update core logging to match terminology

## Testing
- just lint-js
- just lint-rs
- just test