### PR TITLE
Add macOS Homebrew installer option

### DIFF
--- a/website/src/routes/download/+page.svelte
+++ b/website/src/routes/download/+page.svelte
@@ -13,6 +13,7 @@ const baseUrl = "https://github.com/futurekittylabs/kittynode";
 const changelogUrl = `${baseUrl}/releases`;
 const releaseUrl = `${baseUrl}/releases/download/kittynode-app-${appVersion}`;
 const cliInstallCommandUnix = `curl --proto '=https' --tlsv1.2 -LsSf https://kittynode.com/sh | sh`;
+const cliInstallCommandHomebrew = "brew install futurekittylabs/tap/kittynode";
 const cliInstallCommandWindows = `powershell -ExecutionPolicy Bypass -c "irm https://kittynode.com/ps1 | iex"`;
 
 const releaseDateFormatter = new Intl.DateTimeFormat("en-US", {
@@ -35,12 +36,14 @@ const cliReleaseDate = formatReleaseDate(cliPubDate);
 
 const appVersionLabel = `Version ${appVersion}`;
 const cliVersionLabel = `Version ${cliVersion}`;
+const installsContainerClass =
+  "mx-auto flex w-full flex-col gap-4 max-w-full sm:max-w-xl lg:max-w-[48rem]";
 
 const downloads = [
   {
     name: "Linux",
     icon: Terminal,
-    requirements: "Linux",
+    requirements: "Most Linux distros",
     variants: [
       {
         label: "x86_64",
@@ -146,9 +149,7 @@ const downloads = [
             {/if}
           </p>
         </div>
-        <div
-          class="mx-auto flex w-full flex-col gap-4 max-w-full sm:max-w-xl lg:max-w-2xl"
-        >
+        <div class={installsContainerClass}>
           {#each downloads as info}
             <div class="rounded-lg border bg-card p-5">
               <div
@@ -228,14 +229,14 @@ const downloads = [
             {/if}
           </p>
         </div>
-        <div class="mx-auto flex w-full flex-col gap-4">
+        <div class={installsContainerClass}>
           <div class="rounded-lg border bg-card p-5 space-y-3">
             <div class="flex items-center gap-3">
               <div class="rounded-md bg-muted p-1.5">
                 <Terminal class="h-5 w-5" />
               </div>
               <div>
-                <h3 class="text-base font-medium">Linux / macOS</h3>
+                <h3 class="text-base font-medium">Linux</h3>
                 <p class="text-sm text-muted-foreground">
                   Open a terminal and enter the following:
                 </p>
@@ -249,6 +250,45 @@ const downloads = [
             >
               <Code.CopyButton variant="secondary" />
             </Code.Root>
+          </div>
+          <div class="rounded-lg border bg-card p-5 space-y-3">
+            <div class="flex items-center gap-3">
+              <div class="rounded-md bg-muted p-1.5">
+                <AppWindowMac class="h-5 w-5" />
+              </div>
+              <div>
+                <h3 class="text-base font-medium">macOS</h3>
+                <p class="text-sm text-muted-foreground">
+                  Choose your preferred install method:
+                </p>
+              </div>
+            </div>
+            <Tabs.Root value="shell">
+              <Tabs.List aria-label="macOS install options" class="mb-3 flex gap-2">
+                <Tabs.Trigger value="shell" class="px-3">shell</Tabs.Trigger>
+                <Tabs.Trigger value="homebrew" class="px-3">homebrew</Tabs.Trigger>
+              </Tabs.List>
+              <Tabs.Content value="shell">
+                <Code.Root
+                  lang="bash"
+                  class="w-full"
+                  code={cliInstallCommandUnix}
+                  hideLines
+                >
+                  <Code.CopyButton variant="secondary" />
+                </Code.Root>
+              </Tabs.Content>
+              <Tabs.Content value="homebrew">
+                <Code.Root
+                  lang="bash"
+                  class="w-full"
+                  code={cliInstallCommandHomebrew}
+                  hideLines
+                >
+                  <Code.CopyButton variant="secondary" />
+                </Code.Root>
+              </Tabs.Content>
+            </Tabs.Root>
           </div>
           <div class="rounded-lg border bg-card p-5 space-y-3">
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add macOS Homebrew install tab and split linux/macos cards
- keep width consistent across desktop/cli sections and copy update
- expose Homebrew command alongside existing shell installer

## Testing
- just lint-js