### PR TITLE
Redesign website homepage

### DIFF
--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -48,7 +48,7 @@ let active: ScreenshotId = $state("app");
     <Tabs.Root bind:value={active}>
       <Tabs.List aria-label="Screenshot view" class="h-11 p-1">
         {#each screenshotIds as id}
-          <Tabs.Trigger value={id} class="px-6 text-base">{screenshots[id].label}</Tabs.Trigger>
+          <Tabs.Trigger value={id} class="px-5 text-base">{screenshots[id].label}</Tabs.Trigger>
         {/each}
       </Tabs.List>
     </Tabs.Root>


### PR DESCRIPTION
## Summary
- Vertical layout replacing side-by-side hero for a more modern, scrollable experience
- Larger screenshot showcase that breaks out of container (1080px max)
- New headline: "Run Ethereum at home"
- Four curated features in 2x2 grid: Package ecosystem, One core every surface, Remote access, Minimal by default
- Separate CTAs: Download in hero, docs link at bottom (no duplicate buttons)

## Test plan
- [ ] Verify homepage renders correctly on desktop
- [ ] Verify responsive layout on mobile (features stack to single column)
- [ ] Check light/dark mode screenshot switching
- [ ] Verify all links work (download, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)